### PR TITLE
__ALL__ fixed

### DIFF
--- a/termcolor.py
+++ b/termcolor.py
@@ -28,7 +28,7 @@ import os
 import re
 
 
-__ALL__ = [ 'colored', 'cprint' ]
+__all__ = [ 'colored', 'cprint' ]
 
 VERSION = (1, 1, 0)
 


### PR DESCRIPTION
`__ALL__` changed to `__all__`  since it is case sensitive and doesn't work with `__ALL__`